### PR TITLE
Fix for cookie banner always displayed

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -4,30 +4,6 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://thelia.net/schema/dic/config http://thelia.net/schema/dic/config/thelia-1.0.xsd">
 
-    <loops>
-        <!-- sample definition
-        <loop name="MySuperLoop" class="HookCurrency\Loop\MySuperLoop" />
-        -->
-    </loops>
-
-    <forms>
-        <!--
-        <form name="MyFormName" class="HookCurrency\Form\MySuperForm" />
-        -->
-    </forms>
-
-    <commands>
-        <!--
-        <command class="HookCurrency\Command\MySuperCommand" />
-        -->
-    </commands>
-
-    <!--
-    <services>
-
-    </services>
-    -->
-
     <hooks>
         <hook id="hookcookiescss.hook.front" class="HookCookies\Hook\FrontHookCookies" scope="request">
             <tag name="hook.event_listener" event="main.stylesheet" type="front" method="addCookiesCSS" />

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -4,16 +4,16 @@
         xsi:schemaLocation="http://thelia.net/schema/dic/module http://thelia.net/schema/dic/module/module-2_1.xsd">
     <fullnamespace>HookCookies\HookCookies</fullnamespace>
     <descriptive locale="en_US">
-        <title>Block cookies</title>
+        <title>Cookie warning block</title>
     </descriptive>
     <descriptive locale="fr_FR">
-        <title>Bloc cookies</title>
+        <title>Bloc d'avertissement sur l'usage des cookies</title>
     </descriptive>
     <languages>
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>0.2</version>
+    <version>0.3</version>
     <author>
         <name>Damien Foulhoux</name>
         <email>dfoulhoux@openstudio.fr</email>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+This module displays a simple dismissable cookie warning banner at the bottom of your shop.
+
 Just activate it !

--- a/templates/frontOffice/default/assets/css/cookie-headband.css
+++ b/templates/frontOffice/default/assets/css/cookie-headband.css
@@ -7,11 +7,11 @@
     width: 100%;
     z-index: 99;
     color: #000;
-
-
 }
 
-#cookie-headband .container{background: transparent;}
+#cookie-headband .container{
+    background: transparent;
+}
 
 #cookie-headband button.close {
     font-size: 50px;

--- a/templates/frontOffice/default/assets/js/cookie-headband.js
+++ b/templates/frontOffice/default/assets/js/cookie-headband.js
@@ -1,0 +1,56 @@
+(function($) {
+    
+    var elem;
+    var params;
+    
+    $.fn.cookieHeadband = function(args) {
+        var options = {
+            openClass : 'open',
+            closeClass : 'close',
+            closeBtn : $('#cookie-headband-close')
+        };
+        
+        params = $.extend(options, args);
+        
+        return this.each(function() {
+            
+            elem = this;
+            var $closeBtn = params.closeBtn;
+            
+            initHeadband();
+            
+            $closeBtn.on('click', function() {
+                closeHeadband();
+                
+                return false;
+            });
+            
+        });
+    };
+    
+    function initHeadband() {
+        if (typeof(Storage) !== "undefined") {
+            if (localStorage.cookieHeadband === undefined) {
+                localStorage.cookieHeadband = 'open';
+                
+                $(elem).addClass(params.openClass);
+            } else {
+                if (localStorage.cookieHeadband === "open") {
+                    $(elem).addClass(params.openClass);
+                } else {
+                    closeHeadband();
+                }
+            }
+        }
+    }
+    
+    function closeHeadband() {
+        if (localStorage.cookieHeadband === "open") {
+            localStorage.setItem("cookieHeadband", "closed");
+        }
+        
+        $(elem).removeClass(params.openClass);
+        $(elem).addClass(params.closeClass);
+    }
+    
+})(jQuery);

--- a/templates/frontOffice/default/cookie-headband.html
+++ b/templates/frontOffice/default/cookie-headband.html
@@ -1,6 +1,6 @@
 <div id="cookie-headband" class="alert fade in" role="alert">
     <div class="container">
-        <button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
+        <button id="cookie-headband-close" type="button" class="close" data-dismiss="alert"><span aria-hidden="true">×</span><span class="sr-only">Close</span></button>
         <p>
            {intl l="Cookies help us provide our services and to offer you personalized experiences. By using this site, you agree to our use of cookies. You can change your preferences at any time." d="hookcookies.fo.default"}
         </p>


### PR DESCRIPTION
The close button was missing the "cookie-headband-close" ID, which prevented the module to write the dismiss flag in the local browser storage.

The source of the cookie-headband.min.js was added to the js directory.